### PR TITLE
Fix NaN bug in backward().

### DIFF
--- a/nn.py
+++ b/nn.py
@@ -196,7 +196,7 @@ class WRMSSE(nn.Module):
         # compute WRMSSE loss
         squared_errors = (actual_sales - projected_sales)**2
         MSE = torch.sum(squared_errors, dim=1) / horizon
-        RMSSE = torch.sqrt(MSE / self.scales)
+        RMSSE = torch.sqrt(MSE / self.scales + 1e-18)
         loss = torch.sum(self.weights * RMSSE)
 
         return loss

--- a/utils/data.py
+++ b/utils/data.py
@@ -52,12 +52,6 @@ class ForecastDataset(Dataset):
         self.prices = self._sell_prices(calendar, prices)
         self.sales = self._unit_sales(sales)
 
-        # normalize inputs to unit Gaussian distribution
-        self.day = (self.day - 1.4436644) / 6.093091
-        self.snap = (self.snap - 2.029751) / 3.42601
-        self.prices = (self.prices - 2.029751) / 3.42601
-        self.sales = (self.sales - 2.029751) / 3.42601
-
         self.seq_len = seq_len
         self.horizon = horizon
 
@@ -165,6 +159,10 @@ class ForecastDataset(Dataset):
             axis=2
         )
 
+        # normalize inputs to unit Gaussian distribution
+        day = (day - 1.4436644) / 6.093091
+        items = (items - 2.029751) / 3.42601
+
         # get targets in shape (N, |targets|)
         targets = self.sales[end_idx:end_idx + self.horizon].T
 
@@ -180,6 +178,10 @@ class ForecastDataset(Dataset):
             self.prices[idx + 1:idx + 2].T,
             self.sales[idx:idx + 1].T)
         )[np.newaxis]
+
+        # normalize inputs to unit Gaussian distribution
+        day = (day - 1.4436644) / 6.093091
+        items = (items - 2.029751) / 3.42601
 
         return day, items
 


### PR DESCRIPTION
Apparently, you can't do `backward()` when you give 0 as input to `torch.sqrt()`. So I added a small number such that never occurs and the problem seems to be fixed.