### PR TITLE
Sliding window with block skips

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     print('DEVICE:', device)
 
     # initialize network and show summary
-    model = Model(args.horizon, args.num_models, device, not args.dependent)
+    model = Model(args.num_models, device, not args.dependent)
 
     # TensorBoard writers
     current_time = datetime.now().strftime("%Y-%m-%d/%H'%M'%S")

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ if __name__ == '__main__':
 
     # use GPU if available
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = torch.device('cpu')
     print('DEVICE:', device)
 
     # initialize network and show summary

--- a/main.py
+++ b/main.py
@@ -54,7 +54,6 @@ if __name__ == '__main__':
 
     # use GPU if available
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    device = torch.device('cpu')
     print('DEVICE:', device)
 
     # initialize network and show summary

--- a/optim.py
+++ b/optim.py
@@ -74,9 +74,11 @@ def train(model, train_loader, train_writer, optimizer, criterion, epoch):
         Number of days the model has been trained on in current epoch.
     """
     num_days = 0
-    for day, items, t in tqdm(train_loader, desc=f'Train Epoch {epoch}'):
+    for data in tqdm(train_loader, desc=f'Train Epoch {epoch}'):
+        day, items, t_day, t_items = data
+
         # predict sales projections
-        y = model(day, items)
+        y = model(day, items, t_day, t_items)
 
         # compute loss and show on TensorBoard every 100 iterations
         loss = criterion(y, t)

--- a/optim.py
+++ b/optim.py
@@ -78,10 +78,10 @@ def train(model, train_loader, train_writer, optimizer, criterion, epoch):
         day, items, t_day, t_items = data
 
         # predict sales projections
-        y = model(day, items, t_day, t_items)
+        y = model(day, items, t_day[:, :-1], t_items[:, :-1])
 
         # compute loss and show on TensorBoard every 100 iterations
-        loss = criterion(y, t)
+        loss = criterion(y, t_items[:, 1:, :, 2].permute(0, 2, 1))
         train_writer.show_loss(loss, day.shape[1])
 
         # update model's parameters

--- a/optim.py
+++ b/optim.py
@@ -81,7 +81,7 @@ def train(model, train_loader, train_writer, optimizer, criterion, epoch):
         y = model(day, items, t_day[:, :-1], t_items[:, :-1])
 
         # compute loss and show on TensorBoard every 100 iterations
-        loss = criterion(y, t_items[:, 1:, :, 2].permute(0, 2, 1))
+        loss = criterion(y, t_items[0, 1:, :, 2])
         train_writer.show_loss(loss, day.shape[1])
 
         # update model's parameters
@@ -114,26 +114,37 @@ def validate(model, val_loader, val_writer, criterion, epoch, num_days):
 
     # start iterator with actual sales from previous day
     val_loader = iter(val_loader)
-    day, items, t = None, None, None
+    day, items, t_day, t_items = None, None, None, None
     for _ in range(ForecastDataset.start_idx + num_days + 1):
-        day, items, t = next(val_loader)
+        day, items, t_day, t_items = next(val_loader)
 
     with torch.no_grad():
         # initialize sales and targets columns for current day
-        y = model(day, items)
-        sales = y[..., :1]
-        targets = t[..., :1]
+        y = model(day, items, t_day[:, :-1], t_items[:, :-1])
+        sales = y
+        targets = t_items[0, 1:, :, 2]
 
-        for day, items, t in tqdm(val_loader, desc=f'Validation Epoch {epoch}'):
+        # add sales and targets for current day
+        day, items, t_day, t_items = next(val_loader)
+        t_items[0, 0, :, 2] = sales[-1]
+
+        y = model(day, items, t_day[:, :-1], t_items[:, :-1])
+        sales = torch.cat((sales, y))
+        targets = torch.cat((targets, t_items[0, 1:, :, 2]))
+
+        for data in tqdm(val_loader, desc=f'Validation Epoch {epoch}'):
+            day, items, t_day, t_items = data
+
             # replace actual sales in items with projected sales
-            items[:, 0, :, 2] = sales[..., -1]
+            items[0, 0, :, 2] = sales[-2]
+            t_items[0, 0, :, 2] = sales[-1]
 
             # predict with sales projections from previous days
-            y = model(day, items)
+            y = model(day, items, t_day[:, :-1], t_items[:, :-1])
 
             # add sales projections and targets to tables
-            sales = torch.cat((sales, y[..., :1]), dim=2)
-            targets = torch.cat((targets, t[..., :1]), dim=2)
+            sales = torch.cat((sales, y))
+            targets = torch.cat((targets, t_items[0, 1:, :, 2]))
 
     # compute loss over whole horizon and show on TensorBoard
     loss = criterion(sales, targets)

--- a/utils/data.py
+++ b/utils/data.py
@@ -10,7 +10,7 @@ class ForecastDataset(Dataset):
     """Dataset to load forecasts.
 
     Attributes:
-        day       = [np.ndarray] data constant per store-item
+        day       = [np.ndarray] data constant per store-item group
         snap      = [np.ndarray] whether or not SNAP purchases are allowed
         prices    = [np.ndarray] sell prices of each item at all stores
         sales     = [np.ndarray] unit sales of each item at all stores
@@ -77,8 +77,8 @@ class ForecastDataset(Dataset):
 
     @staticmethod
     def _years(calendar):
-        """One-hot representation of years of shape (days, 6)."""
-        return pd.RangeIndex(2011, 2017) == calendar[['year']]
+        """One-hot representation of years of shape (days, 3)."""
+        return pd.RangeIndex(2014, 2017) == calendar[['year']]
 
     @staticmethod
     def _event_types(calendar):
@@ -140,6 +140,29 @@ class ForecastDataset(Dataset):
             return len(self.prices) - 1
 
     def _get_train_item(self, idx):
+        """Get input and target data during training or validation.
+
+        Each epoch, a different starting index is sampled to increase data
+        diversity.
+        The actual size of the returned arrays might not be exactly seq_len
+        and horizon, but since the model can handle an arbitrary sequence
+        length, that is not really a problem.
+
+        Returns [[np.ndarray]*4]:
+            day   = input data constant per store-item of shape (seq_len, 29)
+            t_day = target data constant per store-item of shape (horizon, 29)
+                weekdays  = one-hot vectors of shape (T, 7)
+                weeks     = integers in range [1, 53] of shape (T, 1)
+                monthdays = integers in range [1, 31] of shape (T, 1)
+                months    = one-hot vectors of shape (T, 12)
+                years     = one-hot vectors of shape (T, 3)
+                events    = one-hot vectors of shape (T, 5)
+            items   = input data unequal per store-item; shape (seq_len, N, 3)
+            t_items = target data unequal per store-item; shape (horizon, N, 3)
+                snap      = booleans of shape (T, 30490)
+                prices    = floats of shape (T, 30490)
+                sales     = integers of shape (T, 30490)
+        """
         # pick random start index to get different data each epoch
         if idx == 0:
             ForecastDataset.start_idx = random.randrange(self.seq_len)
@@ -147,27 +170,19 @@ class ForecastDataset(Dataset):
         # determine index at start and end of sequence
         idx = idx * self.seq_len + self.start_idx
         end_idx = min(idx + self.seq_len, len(self.sales) - 2)
+        targets_end_idx = min(end_idx + self.horizon + 1, len(self.sales))
 
-        # get data constant per store-item
+        # get data constant per store-item group
         day = self.day[idx + 1:end_idx + 1]
+        targets_day = self.day[end_idx + 1:targets_end_idx + 1]
 
-        # stack all data different per store-item
+        # stack all data different per store-item group
         items = np.stack((
             self.snap[idx + 1:end_idx + 1],
             self.prices[idx + 1:end_idx + 1],
             self.sales[idx:end_idx]),
             axis=2
         )
-
-        # normalize inputs to unit Gaussian distribution
-        day = (day - 1.4436644) / 6.093091
-        items = (items - 2.029751) / 3.42601
-
-        # get data constant per store-item
-        targets_end_idx = min(end_idx + self.horizon + 1, len(self.sales))
-        targets_day = self.day[end_idx + 1:targets_end_idx + 1]
-
-        # stack all data different per store-item
         targets_items = np.stack((
             self.snap[end_idx + 1:targets_end_idx + 1],
             self.prices[end_idx + 1:targets_end_idx + 1],
@@ -178,43 +193,7 @@ class ForecastDataset(Dataset):
         return day, items, targets_day, targets_items
 
     def _get_inference_item(self, idx):
-        # get data constant per store-item
-        day = self.day[np.newaxis, idx + 1]
-
-        # stack only SNAP and prices data; sales has variable length
-        items = np.hstack((
-            self.snap[idx + 1:idx + 2].T,
-            self.prices[idx + 1:idx + 2].T,
-            self.sales[idx:idx + 1].T)
-        )[np.newaxis]
-
-        # normalize inputs to unit Gaussian distribution
-        day = (day - 1.4436644) / 6.093091
-        items = (items - 2.029751) / 3.42601
-
-        return day, items
-
-    def __getitem__(self, idx):
-        """Get data for self.seq_len days and targets for self.horizon days.
-
-        If horizon > 0, i.e. training or validation mode, the targets need to be
-        returned. Sales does not have a variable length, so it can be returned
-        within items. So then day, items with sales, and targets are returned.
-
-        Returns [[np.ndarray]*3]:
-            day     = data constant per store-item of shape (seq_len, 32)
-                weekdays  = one-hot vectors of shape (seq_len, 7)
-                weeks     = integers in range [1, 53] of shape (seq_len, 1)
-                monthdays = integers in range [1, 31] of shape (seq_len, 1)
-                months    = one-hot vectors of shape (seq_len, 12)
-                years     = one-hot vectors of shape (seq_len, 6)
-                events    = one-hot vectors of shape (seq_len, 5)
-            items   = data different per store-item of shape (seq_len, 3, N)
-                snap      = booleans of shape (seq_len, N)
-                prices    = floats of shape (seq_len, N)
-                sales     = integers of shape (seq_len, N)
-            targets = unit sales of next days of shape (N, |targets|),
-                where 1 <= |targets| <= horizon
+        """Get input data during inference.
 
         If horizon = 0, i.e. inference mode, then sales may be empty, which
         means that items may not contian sales. So then day and items
@@ -234,6 +213,23 @@ class ForecastDataset(Dataset):
                 sales     = unit sales of previous day of shape (|sales|, N),
                     where 0 <= |sales| <= 1
         """
+        # get data constant per store-item
+        day = self.day[np.newaxis, idx + 1]
+
+        # stack only SNAP and prices data; sales has variable length
+        items = np.hstack((
+            self.snap[idx + 1:idx + 2].T,
+            self.prices[idx + 1:idx + 2].T,
+            self.sales[idx:idx + 1].T)
+        )[np.newaxis]
+
+        # normalize inputs to unit Gaussian distribution
+        day = (day - 1.4436644) / 6.093091
+        items = (items - 2.029751) / 3.42601
+
+        return day, items
+
+    def __getitem__(self, idx):
         if self.horizon:  # training or validation mode
             return self._get_train_item(idx)
         else:  # inference mode

--- a/utils/data.py
+++ b/utils/data.py
@@ -135,7 +135,7 @@ class ForecastDataset(Dataset):
     def __len__(self):
         """Returns number of items in the dataset."""
         if self.horizon:
-            return (len(self.sales) - 1) // self.seq_len
+            return (len(self.sales) - 2) // self.seq_len
         else:
             return len(self.prices) - 1
 
@@ -146,7 +146,7 @@ class ForecastDataset(Dataset):
 
         # determine index at start and end of sequence
         idx = idx * self.seq_len + self.start_idx
-        end_idx = min(idx + self.seq_len, len(self.sales) - 1)
+        end_idx = min(idx + self.seq_len, len(self.sales) - 2)
 
         # get data constant per store-item
         day = self.day[idx + 1:end_idx + 1]
@@ -164,7 +164,7 @@ class ForecastDataset(Dataset):
         items = (items - 2.029751) / 3.42601
 
         # get data constant per store-item
-        targets_end_idx = min(end_idx + self.horizon, len(self.sales))
+        targets_end_idx = min(end_idx + self.horizon + 1, len(self.sales))
         targets_day = self.day[end_idx + 1:targets_end_idx + 1]
 
         # stack all data different per store-item


### PR DESCRIPTION
The sliding window through the data wasn't practical, because of low data diversity.
The blocks through the data wasn't practical, because the output wasn't a sequence.
So I've combined the best of both worlds.
By setting seq_len = 1 when making the dataloaders, you can get the sliding window approach.
By setting horizon = 1, you can get the blocks approach.
The current settings are probably better.
The hidden state of an LSTM can be saved, as long as you don't do a `backward()` in between. After the `backward()`, the hidden state is detached from the computational graph, just like before.