### PR TITLE
Generalized inter-group independencies

### DIFF
--- a/kaggle.py
+++ b/kaggle.py
@@ -7,35 +7,26 @@ from utils.data import data_frames, ForecastDataset
 from nn import Model
 
 
-def infer(model, loader, window_size):
-    """Infer unit sales of next days with the model.
+def infer(model, loader):
+    """Infer unit sales of next days with a trained model.
 
     Args:
         model       = [nn.Module] trained model
-        loader      = [DataLoader] dataloader with last year of available data
-        window_size = [int] number of projections to take the average over
+        loader      = [DataLoader] DataLoader with last year of available data
 
     Returns [[torch.Tensor]*2]:
         validation = sales projections of next 28 days
-        evaluation = sales projects of next 28 days after validation days
+        evaluation = sales projections of 28 days after validation days
     """
-    # initialize projections and window size as tensors
+    # initialize projections as tensor
     projections = torch.zeros(len(loader), 30490)
-    window_size = torch.tensor(window_size)
 
     with torch.no_grad():
         for i, (day, items, sales) in enumerate(tqdm(loader)):
             # find missing sales in projections
             start_idx = sales.shape[1] - 2 + i
-            end_idx = items.shape[1] - 2 + i
-            projection = projections[start_idx:end_idx]
-
-            # take average of projection
-            length = window_size + 1 - items.shape[1]
-            num_sums = torch.arange(len(projection) + length, length, step=-1)
-            num_sums = torch.min(num_sums, window_size)
-            projection = projection / num_sums.view(-1, 1)
-            projection = projection.view(1, len(projection), 30490, 1)
+            projection = projections[start_idx:i]
+            projection = projection.view(1, projection.shape[0], 30490, 1)
 
             # concatenate inputs
             sales = torch.cat((sales, projection), dim=1)
@@ -43,20 +34,19 @@ def infer(model, loader, window_size):
 
             # add new projections based on old projections
             y = model(day[:, :1], items[:, :1], day[:, 1:], items[:, 1:])
-            projections[i:i + y.shape[0]] += y
+            projections[i:i + 1] += y
 
     # select validation and evaluation projections from all projections
-    validation = projections[-56:-28] / window_size
-    evaluation = projections[-28:] / window_size
+    validation = projections[-56:-28].T
+    evaluation = projections[-28:].T
 
-    return validation.T, evaluation.T
+    return validation, evaluation
 
 
 if __name__ == '__main__':
     device = torch.device('cpu')
-    num_models = 1500  # number of submodels
-    num_days = 10  # number of days prior the days with missing sales
-    window_size = 8  # how much rolling average to apply
+    num_models = 300  # number of submodels
+    num_days = 365  # number of days prior the days with missing sales
 
     # initialize trained model on correct device
     model = Model(num_models, device)
@@ -77,19 +67,23 @@ if __name__ == '__main__':
     sales = sales.sort_values(by=['store_id', 'item_id'])
     sales.index = range(sales.shape[0])
 
-    dataset = ForecastDataset(calendar, prices, sales,
-                              seq_len=window_size, horizon=0)
+    # make dataloader from data
+    dataset = ForecastDataset(calendar, prices, sales, seq_len=1, horizon=0)
     loader = DataLoader(dataset)
 
-    validation, evaluation = infer(model, loader, window_size)
+    # run model to get sales projections
+    validation, evaluation = infer(model, loader)
 
+    # add validation projections to DataFrame
     columns = [f'F{i}' for i in range(1, 29)]
     validation = pd.DataFrame(validation.tolist(), columns=columns)
     validation = pd.concat((sales[['id']], validation), axis=1)
 
+    # add evaluation projections to DataFrame
     eval_id_col = sales[['id']].applymap(lambda x: x[:-10] + 'evaluation')
     evaluation = pd.DataFrame(evaluation.tolist(), columns=columns)
     evaluation = pd.concat((eval_id_col, evaluation), axis=1)
 
+    # concatenate all projections and save to storage
     projections = pd.concat((validation, evaluation), axis=0)
     projections.to_csv('submission.csv', index=False)

--- a/kaggle.py
+++ b/kaggle.py
@@ -7,30 +7,38 @@ from utils.data import data_frames, ForecastDataset
 from nn import Model
 
 
-def infer(model, loader):
+def infer(model, loader, window_size):
     """Infer the unit sales with the model.
 
     Args:
-        model  = [nn.Module] trained model
-        loader = [DataLoader] dataloader with last year of available data
+        model       = [nn.Module] trained model
+        loader      = [DataLoader] dataloader with last year of available data
+        window_size = [int] number of projections to take the average over
 
     Returns [[torch.Tensor]*2]:
         validation = sales projections of next 28 days
         evaluation = sales projects of next 28 days after validation
     """
-    projections = []
+    # initialize
+    projections = torch.zeros(30490, len(loader) + window_size - 1)
 
     with torch.no_grad():
-        for day, items in tqdm(loader):
+        for i, (day, items) in enumerate(tqdm(loader)):
             if items.shape[-1] == 2:  # use sales projections at end of data
-                projection = projections[-1].view(1, 1, -1, 1).to('cpu')
+                projection = projections[:, i - 1] / window_size
+                projection = projection.view(1, 1, -1, 1).to('cpu')
                 items = torch.cat((items, projection), dim=-1)
 
             y = model(day, items)
-            projections.append(y[0, :, 0])
-        
-    validation = torch.stack(projections[-56:-28], dim=-1)
-    evaluation = torch.stack(projections[-28:], dim=-1)
+            projections[:, i:i + window_size] += y[0, :, :window_size]
+
+    # select validation and evaluation projections from all projections
+    eval_idx = -28 - window_size + 1
+    validation = projections[:, eval_idx - 28:eval_idx]
+    if window_size == 1:
+        evaluation = projections[:, eval_idx:]
+    else:
+        evaluation = projections[:, eval_idx:-window_size + 1]
 
     return validation, evaluation
 
@@ -38,8 +46,9 @@ def infer(model, loader):
 if __name__ == '__main__':
     device = torch.device('cpu')
     horizon = 5  # forecasting horizon
-    num_models = 4000
-    num_days = 36
+    num_models = 4000  # number of submodels
+    num_days = 36  # number of days prior the days with missing sales
+    window_size = 1  # how much rolling average to apply, window_size <= horizon
 
     # initialize trained model on correct device
     model = Model(horizon, num_models, device)
@@ -63,7 +72,7 @@ if __name__ == '__main__':
     dataset = ForecastDataset(calendar, prices, sales, seq_len=1, horizon=0)
     loader = DataLoader(dataset)
 
-    validation, evaluation = infer(model, loader)
+    validation, evaluation = infer(model, loader, window_size)
     columns = [f'F{i}' for i in range(1, 29)]
 
     validation = pd.DataFrame(validation.tolist(), columns=columns)

--- a/kaggle.py
+++ b/kaggle.py
@@ -3,7 +3,7 @@ import torch
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from utils.data import ForecastDataset
+from utils.data import data_frames, ForecastDataset
 from nn import Model
 
 
@@ -19,36 +19,46 @@ def infer(model, loader):
         evaluation = sales projects of next 28 days after validation
     """
     projections = []
-    for day, items in tqdm(loader):
-        if items.shape[2] == 2:  # use sales projections at end of data
-            projection = projections[-1].view(1, 1, 1, items.shape[-1])
-            items = torch.cat((items, projection.to('cpu')), dim=2)
 
-        y = model(day, items)
-        projections.append(y[:, 0])
+    with torch.no_grad():
+        for day, items in tqdm(loader):
+            if items.shape[-1] == 2:  # use sales projections at end of data
+                projection = projections[-1].view(1, 1, -1, 1).to('cpu')
+                items = torch.cat((items, projection), dim=-1)
+
+            y = model(day, items)
+            projections.append(y[0, :, 0])
         
-    validation = torch.stack(projections[-56:-28], dim=1)
-    evaluation = torch.stack(projections[-28:], dim=1)
+    validation = torch.stack(projections[-56:-28], dim=-1)
+    evaluation = torch.stack(projections[-28:], dim=-1)
 
     return validation, evaluation
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda')
+    device = torch.device('cpu')
     horizon = 5  # forecasting horizon
-    num_models = 1000
+    num_models = 4000
+    num_days = 36
 
-    model = Model(horizon, num_models, device, True)
-    # model.load_state_dict(torch.load('models/model.pt', map_location=device))
+    # initialize trained model on correct device
+    model = Model(horizon, num_models, device)
+    model.load_state_dict(torch.load('models/model.pt', map_location=device))
+    model.reset_hidden()
     model.eval()
 
-    path = ('D:\\Users\\Niels-laptop\\Documents\\2019-2020\\Machine Learning '
-            'in Practice\\Competition 2\\project\\')
-    calendar = pd.read_csv(path + r'\calendar.csv').iloc[-365:]
-    sales = pd.read_csv(path + r'\sales_train_validation.csv')
-    sales = pd.concat((sales.iloc[:, :6], sales.iloc[:, -365+28+28:]), axis=1)
+    path = ('D:/Users/Niels-laptop/Documents/2019-2020/Machine '
+            'Learning in Practice/Competition 2/project')
+    calendar, prices, sales = data_frames(path)
+
+    # get last 365 days of data plus the extra days
+    num_extra_days = calendar.shape[0] - (sales.shape[1] - 6)
+    calendar = calendar.iloc[-num_days - num_extra_days:]
+
+    # get last 365 days of sales data
+    sales = pd.concat((sales.iloc[:, :6], sales.iloc[:, -num_days:]), axis=1)
     sales = sales.sort_values(by=['store_id', 'item_id'])
-    prices = pd.read_csv(path + r'\sell_prices.csv')
+    sales.index = range(sales.shape[0])
 
     dataset = ForecastDataset(calendar, prices, sales, seq_len=1, horizon=0)
     loader = DataLoader(dataset)
@@ -59,9 +69,9 @@ if __name__ == '__main__':
     validation = pd.DataFrame(validation.tolist(), columns=columns)
     validation = pd.concat((sales[['id']], validation), axis=1)
 
+    eval_id_col = sales[['id']].applymap(lambda x: x[:-10] + 'evaluation')
     evaluation = pd.DataFrame(evaluation.tolist(), columns=columns)
-    eval_col = sales[['id']].applymap(lambda x: x[:-10] + 'evaluation')
-    evaluation = pd.concat((eval_col, evaluation), axis=1)
+    evaluation = pd.concat((eval_id_col, evaluation), axis=1)
 
     projections = pd.concat((validation, evaluation), axis=0)
     projections.to_csv('submission.csv', index=False)

--- a/kaggle.py
+++ b/kaggle.py
@@ -19,7 +19,7 @@ def infer(model, loader):
         evaluation = sales projections of 28 days after validation days
     """
     # initialize projections as tensor
-    projections = torch.zeros(len(loader), 30490)
+    projections = torch.empty(len(loader), 30490)
 
     with torch.no_grad():
         for i, (day, items, sales) in enumerate(tqdm(loader)):
@@ -34,7 +34,7 @@ def infer(model, loader):
 
             # add new projections based on old projections
             y = model(day[:, :1], items[:, :1], day[:, 1:], items[:, 1:])
-            projections[i:i + 1] += y
+            projections[i] = y
 
     # select validation and evaluation projections from all projections
     validation = projections[-56:-28].T

--- a/main.py
+++ b/main.py
@@ -23,8 +23,8 @@ def handle_arguments():
                         help='number of days for validation, default: 28')
     parser.add_argument('-s', '--num_models', type=int, default=500,
                         help='number of submodels to make, default: 500')
-    parser.add_argument('-d', '--dropout', type=float, default=1.0,
-                        help='prob of zero inter-group weight, default: 1.0')
+    parser.add_argument('-l', '--inter_group_lr', type=float, default=0.0,
+                        help='LR factor of inter-group weights, default: 0.0')
     parser.add_argument('-e', '--epochs', type=int, default=50,
                         help='number of iters over training data, default: 50')
     parser.add_argument('-m', '--model', type=str, default='models/model.pt',
@@ -57,7 +57,8 @@ if __name__ == '__main__':
     print('DEVICE:', device)
 
     # initialize network and show summary
-    model = Model(args.num_models, device, args.dropout)
+    model = Model(args.num_models, device, args.inter_group_lr)
+
     # TensorBoard writers
     current_time = datetime.now().strftime("%Y-%m-%d/%H'%M'%S")
     train_writer = MetricWriter(f'runs/{current_time}/train')

--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ from utils.tensorboard import MetricWriter
 
 def handle_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument('path', type=str, help='provide path in style: '
-                        r'"kaggle/input/m5-accuracy"')
+    parser.add_argument('path', type=str,
+                        help='provide path where CSV data is stored')
     parser.add_argument('-t', '--num_days', type=int, default=365,
                         help='total number of days to train on, default: 365')
     parser.add_argument('-i', '--seq_len', type=int, default=8,
@@ -23,10 +23,10 @@ def handle_arguments():
                         help='number of days for validation, default: 28')
     parser.add_argument('-s', '--num_models', type=int, default=500,
                         help='number of submodels to make, default: 500')
-    parser.add_argument('-d', '--dependent', action='store_true',
-                        help='switch to have inter-group dependencies')
-    parser.add_argument('-e', '--epochs', type=int, default=50, help='number '
-                        'of iterations over training data, default: 50')
+    parser.add_argument('-d', '--dropout', type=float, default=1.0,
+                        help='prob of zero inter-group weight, default: 1.0')
+    parser.add_argument('-e', '--epochs', type=int, default=50,
+                        help='number of iters over training data, default: 50')
     parser.add_argument('-m', '--model', type=str, default='models/model.pt',
                         help='path to save model, default: "models/model.pt"')
 
@@ -57,8 +57,7 @@ if __name__ == '__main__':
     print('DEVICE:', device)
 
     # initialize network and show summary
-    model = Model(args.num_models, device, not args.dependent)
-
+    model = Model(args.num_models, device, args.dropout)
     # TensorBoard writers
     current_time = datetime.now().strftime("%Y-%m-%d/%H'%M'%S")
     train_writer = MetricWriter(f'runs/{current_time}/train')

--- a/main.py
+++ b/main.py
@@ -23,8 +23,8 @@ def handle_arguments():
                         help='number of days for validation, default: 28')
     parser.add_argument('-s', '--num_models', type=int, default=500,
                         help='number of submodels to make, default: 500')
-    parser.add_argument('-l', '--inter_group_lr', type=float, default=0.0,
-                        help='LR factor of inter-group weights, default: 0.0')
+    parser.add_argument('-d', '--dropout', type=float, default=1.0,
+                        help='prob to drop inter-group weight grad, default: 1')
     parser.add_argument('-e', '--epochs', type=int, default=50,
                         help='number of iters over training data, default: 50')
     parser.add_argument('-m', '--model', type=str, default='models/model.pt',
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     print('DEVICE:', device)
 
     # initialize network and show summary
-    model = Model(args.num_models, device, args.inter_group_lr)
+    model = Model(args.num_models, args.dropout, device)
 
     # TensorBoard writers
     current_time = datetime.now().strftime("%Y-%m-%d/%H'%M'%S")

--- a/nn.py
+++ b/nn.py
@@ -228,7 +228,7 @@ class Dropout:
         Returns [torch.Tensor]:
             Gradients, where on some of self.grad_idx, they are set to zero.
         """
-        sample = self.bernoulli.sample(self.sample_shape)
+        sample = self.bernoulli.sample(self.sample_shape).to(grad.device)
         grad[self.grad_idx] *= sample
 
         return grad

--- a/nn.py
+++ b/nn.py
@@ -401,7 +401,7 @@ class LSTM(nn.Module):
             Output of shape (1, seq_len, num_groups * num_hidden).
         """
         # run LSTM on input
-        y, hidden = self.lstm(input)
+        y, hidden = self.lstm(input, self.hx)
 
         # set or detach hidden and cell states for next iteration
         if keep_hidden:

--- a/nn.py
+++ b/nn.py
@@ -212,7 +212,7 @@ class Dropout:
         """Initializes Dropout module.
 
         Args:
-            p        = [float] probability of setting a weight gradient to zero
+            p        = [torch.Tensor] prob to drop inter-group weight gradient
             grad_idx = [[torch.Tensor]*2] index arrays to apply Dropout to
         """
         self.grad_idx = grad_idx
@@ -228,7 +228,7 @@ class Dropout:
         Returns [torch.Tensor]:
             Gradients, where on some of self.grad_idx, they are set to zero.
         """
-        sample = self.bernoulli.sample(self.sample_shape).to(grad.device)
+        sample = self.bernoulli.sample(self.sample_shape)
         grad[self.grad_idx] *= sample
 
         return grad
@@ -252,7 +252,7 @@ class Linear(nn.Module):
 
         Args:
             num_groups = [int] number of store-item groups to make layer for
-            dropout    = [float] prob of dropping inter-group weight gradient
+            dropout    = [torch.Tensor] prob to drop inter-group weight gradient
         """
         global num_hidden
 
@@ -333,7 +333,7 @@ class LSTM(nn.Module):
 
         Args:
             num_groups = [int] number of store-item groups to make LSTM for
-            dropout    = [float] prob of dropping inter-group weight gradient
+            dropout    = [torch.Tensor] prob to drop inter-group weight gradient
         """
         global num_const
         global num_var
@@ -462,7 +462,7 @@ class SubModel(nn.Module):
 
         Args:
             num_groups = [int] number of store-item groups to make submodel for
-            dropout    = [float] prob of dropping inter-group weight gradient
+            dropout    = [torch.Tensor] prob to drop inter-group weight gradient
         """
         super(SubModel, self).__init__()
 
@@ -532,6 +532,7 @@ class Model(nn.Module):
         self.num_model_groups[:num_extra_groups] = min_model_groups + 1
         self.num_model_groups = self.num_model_groups.long().tolist()
 
+        dropout = torch.tensor(dropout).to(device)
         self.submodels = nn.ModuleList()
         for num_model_groups in self.num_model_groups:
             submodel = SubModel(num_model_groups, dropout).to(device)

--- a/optim.py
+++ b/optim.py
@@ -111,9 +111,10 @@ def validate(model, val_loader, val_writer, criterion, epoch, num_days):
     model.eval()
 
     # start iterator with actual sales from previous day
+    num_days = ForecastDataset.start_idx + num_days
     val_loader = iter(val_loader)
-    day, items, t = None, None, None
-    for _ in range(ForecastDataset.start_idx + num_days + 1):
+    day, items, t = next(val_loader)
+    for _ in range(num_days):
         day, items, t = next(val_loader)
 
     with torch.no_grad():
@@ -122,7 +123,9 @@ def validate(model, val_loader, val_writer, criterion, epoch, num_days):
         sales = y[..., :1]
         targets = t[..., :1]
 
-        for day, items, t in tqdm(val_loader, desc=f'Validation Epoch {epoch}'):
+        val_iter = tqdm(val_loader, desc=f'Validation Epoch {epoch}',
+                        total=len(val_loader) - num_days - 1)
+        for day, items, t in val_iter:
             # replace actual sales in items with projected sales
             items[:, 0, :, 2] = sales[..., -1]
 

--- a/utils/data.py
+++ b/utils/data.py
@@ -203,20 +203,20 @@ class ForecastDataset(Dataset):
 
         If horizon = 0, i.e. inference mode, then sales may have a different
         sequence length than items. So then day, items, and sales separately,
-        are returned. The size of day and items might be smaller than seq_len
-        and sales may be empty.
+        are returned. The size of day and items might be smaller than
+        seq_len + 1 and sales may be empty.
 
         Returns [[np.ndarray]*3]:
-            day   = data constant per store-item of shape (seq_len, 29)
-                weekdays  = one-hot vector of shape (seq_len, 7)
-                weeks     = integer in range [1, 53] of shape (seq_len, 1)
-                monthdays = integer in range [1, 31] of shape (seq_len, 1)
-                months    = one-hot vector of shape (seq_len, 12)
-                years     = one-hot vector of shape (seq_len, 3)
-                events    = one-hot vector of shape (seq_len, 5)
-            items = data different per store-item of shape (seq_len, 30490, 2)
-                snap      = booleans of shape (seq_len, 30490)
-                prices    = floats of shape (seq_len, 30490)
+            day   = data constant per store-item of shape (seq_len + 1, 29)
+                weekdays  = one-hot vector of shape (seq_len + 1, 7)
+                weeks     = integer in range [1, 53] of shape (seq_len + 1, 1)
+                monthdays = integer in range [1, 31] of shape (seq_len + 1, 1)
+                months    = one-hot vector of shape (seq_len + 1, 12)
+                years     = one-hot vector of shape (seq_len + 1, 3)
+                events    = one-hot vector of shape (seq_len + 1, 5)
+            items = data unequal per store-item of shape (seq_len + 1, 30490, 2)
+                snap      = booleans of shape (seq_len + 1, 30490)
+                prices    = floats of shape (seq_len + 1, 30490)
             sales = sales of previous days per store-item of shape (T, 30490, 1)
         """
         end_idx = idx + self.seq_len + 1

--- a/utils/data.py
+++ b/utils/data.py
@@ -198,7 +198,7 @@ class ForecastDataset(Dataset):
                 months    = one-hot vectors of shape (seq_len, 12)
                 years     = one-hot vectors of shape (seq_len, 6)
                 events    = one-hot vectors of shape (seq_len, 5)
-            items   = data different per store-item of shape (seq_len, 3, N)
+            items   = data different per store-item of shape (seq_len, N, 3)
                 snap      = booleans of shape (seq_len, N)
                 prices    = floats of shape (seq_len, N)
                 sales     = integers of shape (seq_len, N)
@@ -217,7 +217,7 @@ class ForecastDataset(Dataset):
                 months    = one-hot vector of shape (1, 12)
                 years     = one-hot vector of shape (1, 6)
                 events    = one-hot vector of shape (1, 5)
-            items = data different per store-item of shape (1, 2, N) / (1, 3, N)
+            items = data different per store-item of shape (1, N, 2) / (1, N, 3)
                 snap      = booleans of shape (1, N)
                 prices    = floats of shape (1, N)
                 sales     = unit sales of previous day of shape (|sales|, N),

--- a/utils/tensorboard.py
+++ b/utils/tensorboard.py
@@ -13,7 +13,7 @@ class MetricWriter(SummaryWriter):
     """
     num_days = 0
 
-    def __init__(self, log_dir, eval_freq=100):
+    def __init__(self, log_dir, eval_freq=14):
         """Initialize this class as subclass of SummaryWriter.
 
         Args:


### PR DESCRIPTION
Before, we had the `independent` parameter, which either kept or removed all the inter-group weights.
Instead of these two extremes, I've decided to generalize this method with Dropout.
If you set `dropout = 1.0`, then all the inter-group weights are dropped. So this setting is equivalent to `independent = True`.
If you set `dropout = 0.0`, then all the inter-group weights are kept. So this setting is equivalent to `independent = False`.

Hopefully, by setting `dropout` to a value somewhere between 0.0 and 1.0, we get the best of both worlds. (1) we make use of the weights that are not used when `independent = True` and (2) the model does not overfit, because we can tightly control its complexity.

This might just be the trick to get faster convergence for the LSTM method, while hopefully achieving better results than `Prophet`.