### PR TITLE
Forwarddrop

### DIFF
--- a/nn.py
+++ b/nn.py
@@ -223,7 +223,7 @@ class Dropout(nn.Module):
         self.bernoulli = Bernoulli(1 - p)
         self.sample = None
 
-    def __call__(self, input, new_sample):
+    def forward(self, input, new_sample):
         """Forward pass of Dropout module.
 
         Args:

--- a/nn.py
+++ b/nn.py
@@ -236,6 +236,7 @@ class Dropout:
             self.sample = self.bernoulli.sample(self.sample_shape)
 
         if input.requires_grad:  # weights
+            input = input.clone()
             with torch.no_grad():
                 input[self.weight_idx] *= self.sample / self.q
         else:  # gradients


### PR DESCRIPTION
Dropout now also works in the forward pass. The weights can keep track of the Dropout application, so perhaps this will bring about the desired stability.

If `dropout = 1.0`, the algorithm is exactly the same as with `independent= True` during training (zero weights and gradients), but during evaluation all the inter-group weights are non-zero. So this might be bad during evaluation.