### PR TITLE
Pass last target days through model before validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,6 +79,7 @@ if __name__ == '__main__':
              optimizer, scheduler,
              criterion,
              args.epochs,
+             args.num_val_days,
              args.model)
 
     # close TensorBoard writers to flush communication

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def handle_arguments():
                         help='number of iters over training data, default: 50')
     parser.add_argument('-m', '--model', type=str, default='models/model.pt',
                         help='path to save model, default: "models/model.pt"')
-    parser.add_argument('-h', '--num_hidden', type=int, default=5,
+    parser.add_argument('-l', '--num_hidden', type=int, default=5,
                         help='hidden units per store-item group, default: 5')
 
     # parse and print arguments

--- a/utils/data.py
+++ b/utils/data.py
@@ -300,7 +300,7 @@ def data_loaders(calendar, prices, sales,
     sales = pd.concat((sales.iloc[:, :6], sales.iloc[:, -num_days:]), axis=1)
 
     # make DataLoader with only training days
-    train_sales = sales.iloc[:, :-num_val_days]
+    train_sales = sales.iloc[:, :-num_val_days - 1]
     train_loader = DataLoader(ForecastDataset(
          calendar, prices, train_sales, seq_len, horizon
     ))


### PR DESCRIPTION
I finally figured out why the Kaggle leaderboard score was overfitting, while our validation score was not. The train and validation datasets were not properly separated.

In `validate()`, an extra loop is added that iterates over the last target days. So none of the data in `train()` that was passed through the model will be used in `validate()`.